### PR TITLE
Fix missing JSON header

### DIFF
--- a/app/days_calculator.go
+++ b/app/days_calculator.go
@@ -38,7 +38,10 @@ func handleDaysCalculator(w http.ResponseWriter, r *http.Request) {
 	}
 
 	result := calculateDate(daysAgo)
-	json.NewEncoder(w).Encode(Response{Date: result})
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(Response{Date: result}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func main() {
@@ -70,4 +73,3 @@ func main() {
 	fmt.Printf("Server started at http://localhost:%s\n", port)
 	http.ListenAndServe(":"+port, nil)
 }
-


### PR DESCRIPTION
## Summary
- ensure HTTP handler sets `Content-Type: application/json`
- return internal server error when JSON encoding fails

## Testing
- `go vet ./...`
- `go run ./app 1`

------
https://chatgpt.com/codex/tasks/task_e_6869a731cf148330b38aeb941269dacf