### PR TITLE
Fix README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ cd days-calculator
 docker build -t days-calculator .
 docker run --rm --env-file .env -p 8089:8089 days-calculator
 Server started at http://localhost:8089
+```
 
 ## Using the API
 


### PR DESCRIPTION
## Summary
- close the `bash` code block in README

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a4bffded08330b468edca7504350f