### PR TITLE
Rename date function and handler

### DIFF
--- a/app/days_calculator.go
+++ b/app/days_calculator.go
@@ -20,15 +20,15 @@ type Response struct {
 // override it for deterministic output.
 var now = time.Now
 
-// calculateDate computes the date `daysAgo` days before today.
-func calculateDate(daysAgo int) string {
+// dateNDaysAgo returns the date `daysAgo` days prior to today.
+func dateNDaysAgo(daysAgo int) string {
 	currentDate := now()
 	pastDate := currentDate.AddDate(0, 0, -daysAgo)
 	return pastDate.Format("2006/01/02")
 }
 
-// handleDaysCalculator handles HTTP requests for the days calculator
-func handleDaysCalculator(w http.ResponseWriter, r *http.Request) {
+// daysCalculatorHandler handles HTTP requests for the days calculator.
+func daysCalculatorHandler(w http.ResponseWriter, r *http.Request) {
 	daysQuery := r.URL.Query().Get("days")
 	if daysQuery == "" {
 		http.Error(w, "Missing 'days' parameter", http.StatusBadRequest)
@@ -41,7 +41,7 @@ func handleDaysCalculator(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result := calculateDate(daysAgo)
+	result := dateNDaysAgo(daysAgo)
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(Response{Date: result}); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -68,12 +68,12 @@ func main() {
 			fmt.Println("Error: Argument must be a valid integer")
 			os.Exit(1)
 		}
-		fmt.Println(calculateDate(daysAgo))
+		fmt.Println(dateNDaysAgo(daysAgo))
 		return
 	}
 
 	// Start the HTTP server
-	http.HandleFunc("/api/calculate", handleDaysCalculator)
+	http.HandleFunc("/api/calculate", daysCalculatorHandler)
 	fmt.Printf("Server started at http://localhost:%s\n", port)
 	http.ListenAndServe(":"+port, nil)
 }

--- a/app/days_calculator_test.go
+++ b/app/days_calculator_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func TestCalculateDate(t *testing.T) {
+func TestDateNDaysAgo(t *testing.T) {
 	// Save original now function and restore after test
 	originalNow := now
 	defer func() { now = originalNow }()
@@ -24,9 +24,9 @@ func TestCalculateDate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := calculateDate(tt.daysAgo)
+		got := dateNDaysAgo(tt.daysAgo)
 		if got != tt.want {
-			t.Errorf("calculateDate(%d) = %s, want %s", tt.daysAgo, got, tt.want)
+			t.Errorf("dateNDaysAgo(%d) = %s, want %s", tt.daysAgo, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- rename `calculateDate` to `dateNDaysAgo`
- rename `handleDaysCalculator` to `daysCalculatorHandler`
- update references and comments
- adjust tests accordingly

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a4eac4c8c8330aeb3def5415a6caf