### PR TITLE
Add CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,17 @@ curl "http://localhost:8089/api/calculate?days=2"
 ### Example Response
 {"date":"2024/12/21"}
 
+## Using the CLI
+
+In addition to the HTTP API, the tool can be run directly from the command line.
+Build and run the binary with a `-days` flag or a positional argument:
+
+```bash
+go build -o days_calculator ./app/days_calculator.go
+./days_calculator -days 5   # using flag
+./days_calculator 3         # using positional argument
+```
+
+Both commands output the date N days prior to today.
+
 

--- a/app/cli_test.go
+++ b/app/cli_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func fixedNow() time.Time {
+	return time.Date(2025, time.January, 8, 12, 0, 0, 0, time.UTC)
+}
+
+func TestRunCLIFlag(t *testing.T) {
+	original := now
+	now = fixedNow
+	defer func() { now = original }()
+
+	got, err := runCLI([]string{"-days", "5"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "2025/01/03" {
+		t.Errorf("got %s want %s", got, "2025/01/03")
+	}
+}
+
+func TestRunCLIPositional(t *testing.T) {
+	original := now
+	now = fixedNow
+	defer func() { now = original }()
+
+	got, err := runCLI([]string{"10"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "2024/12/29" {
+		t.Errorf("got %s want %s", got, "2024/12/29")
+	}
+}
+
+func TestRunCLIError(t *testing.T) {
+	if _, err := runCLI([]string{}); err == nil {
+		t.Errorf("expected error for missing args")
+	}
+
+	if _, err := runCLI([]string{"abc"}); err == nil {
+		t.Errorf("expected error for invalid arg")
+	}
+}


### PR DESCRIPTION
## Summary
- add CLI argument parsing with the flag package
- document CLI usage in the README
- test CLI behaviour for flag and positional arguments

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a504535148330b527e2ec3b086d6e